### PR TITLE
personal_sign: 2/3 make it work (don't merge!)

### DIFF
--- a/app/safe/[address]/wc-sign/WalletConnectSignClient.tsx
+++ b/app/safe/[address]/wc-sign/WalletConnectSignClient.tsx
@@ -301,20 +301,11 @@ export default function WalletConnectSignClient({ safeAddress }: { safeAddress: 
           messageData: newSignedMessage.data,
         });
 
-        console.log("SAFE DEBUG: About to send to WalletConnect - approveRequest", {
-          topic: currentRequest.topic,
-          id: currentRequest.id,
-          encodedSignature,
-          length: encodedSignature.length,
-        });
-
         await approveRequest(currentRequest.topic, {
           id: currentRequest.id,
           jsonrpc: "2.0",
           result: encodedSignature,
         });
-
-        console.log("SAFE DEBUG: Successfully sent to WalletConnect");
 
         // Clear from sessionStorage
         if (typeof window !== "undefined") {


### PR DESCRIPTION
From https://github.com/Cyfrin/localsafe.eth/issues/37

I did a quick test (trying to `personal_sign`* into Opensea with a 2/3 Safe and the hash) and was able to make it work. This is a dirty version, just for reference (don't merge haha, in case it breaks something else, since I didn't test extensively)

* This fix is the the "accept terms" when creating an account on opensea, that makes you sign a `personal_sign` messae. Not sure if you were referring to another signature (e.g. eip712 signature)

The issue was primarly two things:
- Wrong safehash (it seems that you need to decode first). Noticed this by comparing the hash with the official Safe UI.
- We were sending only 1 of the two signatures. Noticed this because `encodedSignature` was too short.

let me know if it works for you!