### PR TITLE
fix(seo): make assetPrefix conditional to fix double-slash URLs (SWEAT-2892)

### DIFF
--- a/.github/workflows/deploy-ipfs.yml
+++ b/.github/workflows/deploy-ipfs.yml
@@ -32,6 +32,7 @@ jobs:
         run: pnpm run build
         env:
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
+          NEXT_PUBLIC_IPFS_BUILD: "true"
 
       - name: Deploy to Pinata
         id: pinata

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-declare const process: { env: Record<string, string | undefined> };
-
 // Use relative assetPrefix for IPFS deployments (assets served under /ipfs/<CID>/),
 // empty string for standard domain deployments (localsafe.cyfrin.io).
 const assetPrefix = process.env.NEXT_PUBLIC_IPFS_BUILD === "true" ? "./" : "";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,15 @@
 import type { NextConfig } from "next";
 
+declare const process: { env: Record<string, string | undefined> };
+
+// Use relative assetPrefix for IPFS deployments (assets served under /ipfs/<CID>/),
+// empty string for standard domain deployments (localsafe.cyfrin.io).
+const assetPrefix = process.env.NEXT_PUBLIC_IPFS_BUILD === "true" ? "./" : "";
+
 const nextConfig: NextConfig = {
   output: "export",
   trailingSlash: true,
-  assetPrefix: "./",
+  assetPrefix,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary

`assetPrefix: "./"` is needed for IPFS deployments where assets are served under `/ipfs/<CID>/`, but when served at a root domain like `localsafe.cyfrin.io/` it produces double-slash URLs (e.g. `//_next/static/media/...`). AHREFS flagged this in the SEO audit ([SWEAT-2892](https://linear.app/cyfrin/issue/SWEAT-2892)).

Fixed by making `assetPrefix` conditional on a `NEXT_PUBLIC_IPFS_BUILD` env var. The IPFS deploy workflow now sets this to `true`, so IPFS builds keep the `"./"` prefix. All other builds default to `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)