### PR TITLE
feat: add BattleChain testnet (chain 627)

### DIFF
--- a/app/provider/WagmiConfigProvider.tsx
+++ b/app/provider/WagmiConfigProvider.tsx
@@ -49,6 +49,21 @@ const battlechain = defineChain({
   },
 });
 
+// BattleChain testnet — not yet in viem/chains. Safe suite for chain 627 is
+// registered in vendor/safe/deployments.ts (KNOWN_CHAIN_DEPLOYMENTS).
+const battlechainTestnet = defineChain({
+  id: 627,
+  name: "BattleChain Testnet",
+  nativeCurrency: { decimals: 18, name: "Ether", symbol: "ETH" },
+  rpcUrls: {
+    default: { http: ["https://testnet.battlechain.com:3051"] },
+  },
+  blockExplorers: {
+    default: { name: "BattleChain Explorer", url: "https://explorer.testnet.battlechain.com" },
+  },
+  testnet: true,
+});
+
 // Extend Window interface for E2E testing utilities
 declare global {
   interface Window {
@@ -122,6 +137,10 @@ const withOptionalRpcOverride = (chain: Chain, envRpcUrl: string | undefined): C
 const DEFAULT_CHAINS: Chain[] = [
   addChainIcon(withOptionalRpcOverride(mainnet, process.env.NEXT_PUBLIC_MAINNET_RPC_URL), ethereumIcon.src),
   addChainIcon(withOptionalRpcOverride(battlechain, process.env.NEXT_PUBLIC_BATTLECHAIN_RPC_URL), battlechainIcon.src),
+  addChainIcon(
+    withOptionalRpcOverride(battlechainTestnet, process.env.NEXT_PUBLIC_BATTLECHAIN_TESTNET_RPC_URL),
+    battlechainIcon.src,
+  ),
   addChainIcon(withOptionalRpcOverride(arbitrum, process.env.NEXT_PUBLIC_ARBITRUM_RPC_URL), arbitrumIcon.src),
   addChainIcon(withOptionalRpcOverride(optimism, process.env.NEXT_PUBLIC_OPTIMISM_RPC_URL), optimismIcon.src),
   addChainIcon(withOptionalRpcOverride(base, process.env.NEXT_PUBLIC_BASE_RPC_URL), baseIcon.src),
@@ -157,7 +176,7 @@ export function isMainnetRpcConfigured(chains: Chain[]): boolean {
 // One-time additive migrations for users with a persisted chain list: each step runs
 // exactly once, so removing a migrated-in chain afterwards still sticks.
 const CHAIN_LIST_MIGRATION_KEY = "MSIG_wagmiConfigNetworksMigration";
-const CHAIN_LIST_MIGRATION = 2; // 1: add battlechain (626); 2: battlechain icon
+const CHAIN_LIST_MIGRATION = 3; // 1: add battlechain (626); 2: battlechain icon; 3: add battlechain testnet (627)
 
 function migrateStoredChains(stored: Chain[]): Chain[] {
   const applied = Number(localStorage.getItem(CHAIN_LIST_MIGRATION_KEY) || "0");
@@ -174,6 +193,11 @@ function migrateStoredChains(stored: Chain[]): Chain[] {
     if (index !== -1 && !(migrated[index] as Chain & { iconUrl?: string }).iconUrl) {
       migrated[index] = addChainIcon(migrated[index], battlechainIcon.src);
     }
+  }
+  if (applied < 3 && !migrated.some((chain) => chain.id === battlechainTestnet.id)) {
+    const testnetEntry = DEFAULT_CHAINS.find((chain) => chain.id === battlechainTestnet.id)!;
+    const bcIndex = migrated.findIndex((chain) => chain.id === battlechain.id);
+    migrated.splice(bcIndex === -1 ? migrated.length : bcIndex + 1, 0, testnetEntry);
   }
   return migrated;
 }

--- a/app/vendor/safe/deployments.ts
+++ b/app/vendor/safe/deployments.ts
@@ -174,6 +174,25 @@ export const KNOWN_CHAIN_DEPLOYMENTS: Record<string, KnownChainDeployment> = {
       fallbackHandlerAddress: ["0x115b290ecDe805FD846E0C347f3419A4234Fd673"], // ExtensibleFallbackHandler
     },
   },
+  // BattleChain testnet (chain 627). Safe v1.5.0 suite at chain-specific
+  // addresses. Verified on-chain 2026-06-18: the singleton's VERSION() returns
+  // "1.5.0" and all eight suite addresses have deployed bytecode. As with 626,
+  // trust rests on deployment provenance, not bytecode byte-matching to the
+  // official Safe v1.5.0 release builds.
+  "627": {
+    safeVersion: "1.5.0",
+    addresses: {
+      safeSingletonAddress: "0x71314F3E6B1D9386A1de784B644Cf5D0Dde3bB97",
+      safeProxyFactoryAddress: "0x80DbD037C59521F393fDfE15504c6b6b7969F1a1",
+      fallbackHandlerAddress: "0xc6B2C6982A5643b7702894D4A0901b9371dd1283",
+      multiSendAddress: "0x69BEaBc6824ba1461F53800d9C3F29FFeC7cf408",
+      multiSendCallOnlyAddress: "0xa6a3C9103C062429e459D263bF5EcCd31Effd56C",
+      signMessageLibAddress: "0x930833004d88b8bF3208a216323aFfdf9D40C14C",
+      createCallAddress: "0x670D1c4c5cc72193b352562Ed75B9ae8224E98b3",
+      tokenCallbackHandlerAddress: "0x232898253fABB3a1EB585bdEE4bE2a36f6D6fd64",
+    },
+    alsoTrusted: {},
+  },
 };
 
 /** Safe version of a registered chain-specific suite (e.g. 1.5.0 on battlechain). */

--- a/tests/parity.spec.ts
+++ b/tests/parity.spec.ts
@@ -190,6 +190,19 @@ test.describe("protocol-kit parity", () => {
       true,
     );
 
+    // BattleChain testnet (627) defaults to its own registered v1.5.0 suite
+    expect(getKnownChainSafeVersion(627)).toBe("1.5.0");
+    const battlechainTestnetDefaults = getDefaultContractAddresses(627);
+    expect(battlechainTestnetDefaults.safeSingletonAddress).toBe("0x71314F3E6B1D9386A1de784B644Cf5D0Dde3bB97");
+    expect(battlechainTestnetDefaults.safeProxyFactoryAddress).toBe("0x80DbD037C59521F393fDfE15504c6b6b7969F1a1");
+    expect(battlechainTestnetDefaults.simulateTxAccessorAddress).toBeUndefined();
+    expect(getUntrustedContracts(battlechainTestnetDefaults, 627)).toEqual([]);
+
+    // Testnet addresses are trusted ONLY on chain 627, not on mainnet battlechain (626)
+    const bcTestnetSingleton = "0x71314F3E6B1D9386A1de784B644Cf5D0Dde3bB97";
+    expect(isOfficialDeployment("safeSingletonAddress", bcTestnetSingleton, 627)).toBe(true);
+    expect(isOfficialDeployment("safeSingletonAddress", bcTestnetSingleton, 626)).toBe(false);
+
     // Canonical deployments are trusted on every chain (case-insensitive)
     expect(isOfficialDeployment("safeSingletonAddress", anvilDefaults.safeSingletonAddress!.toLowerCase(), 626)).toBe(
       true,


### PR DESCRIPTION
Adds BattleChain testnet to the chain list and registers its Safe suite so Safe operations resolve correctly — the part the reference PR #68 omitted.

- WagmiConfigProvider: define chain 627, add it to DEFAULT_CHAINS (reusing the existing battlechain icon), and add chain-list migration step 3 so users with a persisted list get it.
- deployments.ts: register the chain-627 Safe v1.5.0 suite in KNOWN_CHAIN_DEPLOYMENTS. The app resolves Safe addresses from here, not the wagmi chain.contracts field PR #68 populated (which nothing reads). Verified on-chain: singleton VERSION() == "1.5.0" and all eight suite addresses have deployed bytecode.
- parity.spec.ts: lock the 627 registry defaults and chain-scoped trust.

Verified: production build, eslint 0/0, prettier, tsc --noEmit.