### PR TITLE
Fix binding hazard on signer wrapper

### DIFF
--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -17,9 +17,9 @@ export async function getMinimalEIP1193Provider(
   const rawProvider = await connector.getProvider();
   const baseProvider = rawProvider as MinimalEIP1193Provider;
   return {
-    request: baseProvider.request,
-    on: baseProvider.on,
-    removeListener: baseProvider.removeListener,
+    request: baseProvider.request.bind(baseProvider),
+    on: baseProvider.on?.bind(baseProvider),
+    removeListener: baseProvider.removeListener?.bind(baseProvider),
   };
 }
 


### PR DESCRIPTION
Without the additional bind the WalletConnect wrapper can fail. This diff ensures that `this` is always properly bound when calling the underlying provider.

Fixes Cyfrin/localsafe.eth#51

I have not run the E2E tests, but I have run this locally and successfully used WalletConnect to deploy and interact with safes.